### PR TITLE
Allows rar install (#60)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ FROM php:8.1-apache
 # Set the working directory in the container.
 WORKDIR /var/www/html/HRProprietary
 
+COPY Documentation/Build/debian.sources /etc/apt/sources.list.d/
+
 # Run install commands.
 RUN apt-get update
 #RUN apt-get upgrade
@@ -19,7 +21,7 @@ RUN apt-get install -y libzip-dev
 RUN docker-php-ext-install gd zip
 RUN apt-get install -y libreoffice-common default-jre libreoffice-java-common poppler-utils
 RUN apt-get install -y clamav unoconv p7zip-full meshlab dia pandoc
-RUN apt-get install -y git python3 zip unzip
+RUN apt-get install -y git python3 zip unzip rar
 
 # Download the latest HRConvert2 source code from the official repository.
 RUN git clone https://github.com/zelon88/HRConvert2

--- a/Documentation/Build/debian.sources
+++ b/Documentation/Build/debian.sources
@@ -1,0 +1,13 @@
+Types: deb
+# http://snapshot.debian.org/archive/debian/20240211T000000Z
+URIs: http://deb.debian.org/debian
+Suites: bookworm bookworm-updates
+Components: main non-free
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+
+Types: deb
+# http://snapshot.debian.org/archive/debian-security/20240211T000000Z
+URIs: http://deb.debian.org/debian-security
+Suites: bookworm-security
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg


### PR DESCRIPTION
The Debian packages configuration file (`/etc/apt/sources.list.d/debian.sources`) was tweaked and repositories for non free software were no present then `rar` was not found for download and install. The fix is to paste a new sources file that allows `non-free` tools to be installed

The side effects is that using non-free tools can be a no go for some users