### PR TITLE
Fix log creation failure

### DIFF
--- a/Documentation/Build/Dockerfile
+++ b/Documentation/Build/Dockerfile
@@ -43,12 +43,6 @@ FROM php:8.1-apache
 RUN mkdir /DATA && \
   mkdir /DATA/HRConvert2
 
-# Set permissions for required directories.
-RUN chmod -R 0755 /DATA && \
-  chown -R www-data:www-data /DATA && \
-  chmod -R 0755 /var/www/html && \
-  chown -R www-data:www-data /var/www/html
-
 # Set the working directory in the container.
 WORKDIR /var/www/html/HRProprietary
 
@@ -86,6 +80,12 @@ RUN apt-get install -y xpdf mkisofs imagemagick meshlab tesseract-ocr tar
 RUN cp HRConvert2/Documentation/Build/php.ini /usr/local/etc/php.ini
 RUN cp HRConvert2/index.html /var/www/html/index.html
 RUN cp HRConvert2/index.html /var/www/html/HRProprietary/index.html
+
+# Set permissions for required directories.
+RUN chmod -R 0755 /DATA && \
+  chown -R www-data:www-data /DATA && \
+  chmod -R 0755 /var/www/html && \
+  chown -R www-data:www-data /var/www/html
 
 # Expose the ports Apache listens on to the host.
 # Set these to whatever ports suits your needs.


### PR DESCRIPTION
Running `docker run -p 8080:80 zelon88/hrconvert2:v3.3.3` and pointing the browser to `http://localhost:8080/` the next error is shown and was not able to use HRConvert2 at all 
> 
> Warning: file_put_contents(/var/www/html/HRProprietary/HRConvert2/Logs/HRConvert2_0_03_25_24_f7d3cae4b83c4e8c755bdfb73b99120d7fc804f5_e2f853e56566.txt): Failed to open stream: Permission denied in /var/www/html/HRProprietary/HRConvert2/convertCore.php on line 192
> ERROR!!! March 25, 2024, 12:15 am, HRConvert2-9, e2f853e56566/59a107cec6ed: Could not verify logging environment!
